### PR TITLE
Run integration tests in a container, enables "native" on Windows

### DIFF
--- a/quarkus-primefaces-extensions/integration-tests/pom.xml
+++ b/quarkus-primefaces-extensions/integration-tests/pom.xml
@@ -24,6 +24,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-docker</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>
@@ -64,6 +68,8 @@
                                 <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                                 <maven.home>${maven.home}</maven.home>
+                                <quarkus.http.host>localhost</quarkus.http.host>
+                                <quarkus.http.port>8081</quarkus.http.port>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>

--- a/quarkus-primefaces-extensions/integration-tests/src/main/docker/Dockerfile.native
+++ b/quarkus-primefaces-extensions/integration-tests/src/main/docker/Dockerfile.native
@@ -1,0 +1,14 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
+RUN microdnf install freetype fontconfig \
+    && microdnf clean all
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root target/*-runner /work/application
+# Permissions fix for Windows
+RUN chmod "ugo+x" /work/application
+EXPOSE 8081
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/quarkus-primefaces-extensions/integration-tests/src/main/resources/application.properties
+++ b/quarkus-primefaces-extensions/integration-tests/src/main/resources/application.properties
@@ -10,5 +10,5 @@ quarkus.locales=ar,ca,cs,de,en,en_US,es,fr,it,ja,mt,nl,pl,pt,pt_BR,ru,sk,uk,zh_C
 # logging
 quarkus.log.console.format=%s%n
 quarkus.log.console.level=INFO
-quarkus.log.file.path=target/debug.log
+quarkus.log.file.path=target/quarkus.log
 quarkus.log.file.enable=true

--- a/quarkus-primefaces-extensions/pom.xml
+++ b/quarkus-primefaces-extensions/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-primefaces-ecosystem</artifactId>
         <version>2.12.2-SNAPSHOT</version>
     </parent>
-    <groupId>io.quarkiverse.primefaces</groupId>
     <artifactId>quarkus-primefaces-extensions-parent</artifactId>
     <packaging>pom</packaging>
     <name>Quarkus PrimeFaces Extensions - Parent</name>

--- a/quarkus-primefaces/integration-tests/pom.xml
+++ b/quarkus-primefaces/integration-tests/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.primefaces</groupId>
@@ -12,31 +13,35 @@
     <skipITs>true</skipITs>
   </properties>
   <dependencies>
-        <dependency>
-            <groupId>io.quarkiverse.primefaces</groupId>
-            <artifactId>quarkus-primefaces</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
-            <artifactId>htmlunit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
+    <dependency>
+      <groupId>io.quarkiverse.primefaces</groupId>
+      <artifactId>quarkus-primefaces</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-container-image-docker</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.sourceforge.htmlunit</groupId>
+      <artifactId>htmlunit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -64,6 +69,8 @@
                 <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                 <maven.home>${maven.home}</maven.home>
+                <quarkus.http.host>localhost</quarkus.http.host>
+                <quarkus.http.port>8081</quarkus.http.port>
               </systemPropertyVariables>
             </configuration>
           </execution>
@@ -91,8 +98,8 @@
       </build>
       <properties>
         <skipITs>false</skipITs>
-        <quarkus.package.type>native</quarkus.package.type>
         <quarkus.native.builder-image>mandrel</quarkus.native.builder-image>
+        <quarkus.package.type>native</quarkus.package.type>
       </properties>
     </profile>
   </profiles>

--- a/quarkus-primefaces/integration-tests/src/main/docker/Dockerfile.native
+++ b/quarkus-primefaces/integration-tests/src/main/docker/Dockerfile.native
@@ -1,0 +1,14 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
+RUN microdnf install freetype fontconfig \
+    && microdnf clean all
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root target/*-runner /work/application
+# Permissions fix for Windows
+RUN chmod "ugo+x" /work/application
+EXPOSE 8081
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/quarkus-primefaces/integration-tests/src/main/resources/application.properties
+++ b/quarkus-primefaces/integration-tests/src/main/resources/application.properties
@@ -3,7 +3,7 @@ quarkus.http.enable-compression=true
 quarkus.http.compress-media-types=*/*
 quarkus.log.console.format=%s%n
 quarkus.log.console.level=INFO
-quarkus.log.file.path=target/debug.log
+quarkus.log.file.path=target/quarkus.log
 quarkus.log.file.enable=true
 # default bean validation locale
 quarkus.default-locale=en


### PR DESCRIPTION
Fix #13 

This PR enables the test suite to run the native executable in a container.
AWT in GraalVM and Quarkus is not supported on Windows to an extent that would satisfy Quarkus Primefaces' needs, so the solution is to run both the build and the runtime in a Linux container.

This PR relies on changes to Quarkus to work with [Podman for Windows](https://github.com/containers/podman/blob/main/docs/tutorials/podman-for-windows.md). I have  these changes in a branch: [issue-31307-q-2.16](https://github.com/Karm/quarkus/tree/issue-31307-q-2.16). I'll open a PR to Quarkus presently.

# How to test?
```
git clone --branch  issue-31307-q-2.16  https://github.com/Karm/quarkus.git
cd quarkus
./mvnw clean install -Dquickly
cd ..
git clone --branch q-issue-31307 https://github.com/Karm/quarkus-primefaces.git
cd quarkus-primefaces/
podman machine start
mvn clean install -Ddocker -Dnative -Dnative.surefire.skip 
       -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true
       -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17
       -Dquarkus.docker.executable-name=podman
       -Dquarkus.native.container-runtime=podman
       -Dquarkus.version=2.16.999-SNAPSHOT
```

I tested:
| System     | Podman | Docker |
|---------------|-------------|-----------|
| CentOS 8 | 4.0.2 :heavy_check_mark:       | 20.10.21 :heavy_check_mark:  |
| Windows 10 | 4.1.0 :heavy_check_mark:  |  20.10.22 :heavy_check_mark:  |

* Example of a run with Podman for Windows: https://karms.biz/pastebin/primefaces-win-success.txt
* Example of a run with Podman for Linux: https://karms.biz/pastebin/primefaces-lin-success.txt

The Windows run takes a very long time, ~30 minutes with Podman, ~54 minutes with Docker Desktop. It's partially due to the nested virtualization situation on my Linux laptop and also due to the sizing of the WSL2 shim that likely could have been configured better than the default.
